### PR TITLE
[RC-003] GenPass implementation

### DIFF
--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsGenPass.cs
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsGenPass.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+namespace CausticsReflective
+{
+    public class ReflectiveCausticsGenPass : ScriptableRenderPass
+    {
+        private static readonly int WaterNormalTexId = Shader.PropertyToID("_WaterNormalTex");
+        private static readonly int WaterHeightTexId = Shader.PropertyToID("_WaterHeightTex");
+        private static readonly int WaterToWorldId = Shader.PropertyToID("_WaterToWorld");
+        private static readonly int WorldToWaterId = Shader.PropertyToID("_WorldToWater");
+        private static readonly int WaterSizeId = Shader.PropertyToID("_WaterSize");
+        private static readonly int WaterGridParamsId = Shader.PropertyToID("_WaterGridParams");
+        private static readonly int WaterNormalTexelSizeId = Shader.PropertyToID("_WaterNormalTexelSize");
+        private static readonly int SunDirId = Shader.PropertyToID("_SunDir");
+        private static readonly int TintId = Shader.PropertyToID("_Tint");
+        private static readonly int IntensityId = Shader.PropertyToID("_Intensity");
+        private static readonly int FresnelF0Id = Shader.PropertyToID("_F0");
+        private static readonly int JacobianGainId = Shader.PropertyToID("_JacobianGain");
+        private static readonly int PlaneToWorldId = Shader.PropertyToID("_PlaneToWorld");
+        private static readonly int WorldToPlaneId = Shader.PropertyToID("_WorldToPlane");
+        private static readonly int PlaneSizeId = Shader.PropertyToID("_PlaneSize");
+        private static readonly int ReceiverResolutionId = Shader.PropertyToID("_ReceiverResolution");
+        private static readonly int PlaneDistanceToleranceId = Shader.PropertyToID("_PlaneDistanceTolerance");
+        private static readonly int PlaneTwoSidedId = Shader.PropertyToID("_PlaneTwoSided");
+
+        private readonly ProfilingSampler _profilingSampler = new("ReflectiveCausticsGen");
+
+        private Material _material;
+
+        public void Setup(Material material)
+        {
+            _material = material;
+        }
+
+        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+        {
+            if (_material == null)
+            {
+                return;
+            }
+
+            var manager = ReflectiveCausticsManager.Instance;
+            if (manager == null)
+            {
+                return;
+            }
+
+            IWaterSurfaceProvider waterProvider = manager.Water;
+            IReadOnlyList<CausticsReceiverPlane> receivers = ReflectiveCausticsManager.Receivers;
+            if (waterProvider == null || receivers.Count == 0)
+            {
+                return;
+            }
+
+            Texture normalTex = waterProvider.NormalTex != null ? waterProvider.NormalTex : Texture2D.normalTexture;
+            Texture heightTex = waterProvider.HeightTex != null ? waterProvider.HeightTex : Texture2D.blackTexture;
+            Vector2 waterSize = waterProvider.WaterSizeMeters;
+            Matrix4x4 waterToWorld = waterProvider.WaterToWorld;
+            Matrix4x4 worldToWater = waterToWorld.inverse;
+            float normalTexelSize = Mathf.Max(1e-4f, waterProvider.NormalTexelSize);
+
+            int gridX = Mathf.Clamp(Mathf.RoundToInt(waterSize.x / normalTexelSize), 1, 8192);
+            int gridY = Mathf.Clamp(Mathf.RoundToInt(waterSize.y / normalTexelSize), 1, 8192);
+            int instanceCount = gridX * gridY;
+            if (instanceCount <= 0)
+            {
+                return;
+            }
+
+            Vector3 sunDir = Vector3.down;
+            if (manager.Sun != null)
+            {
+                sunDir = -manager.Sun.transform.forward;
+            }
+
+            if (sunDir.sqrMagnitude < 1e-6f)
+            {
+                sunDir = Vector3.down;
+            }
+
+            sunDir.Normalize();
+
+            CommandBuffer cmd = CommandBufferPool.Get(_profilingSampler.name);
+            using (new ProfilingScope(cmd, _profilingSampler))
+            {
+                _material.SetTexture(WaterNormalTexId, normalTex);
+                _material.SetTexture(WaterHeightTexId, heightTex);
+                _material.SetMatrix(WaterToWorldId, waterToWorld);
+                _material.SetMatrix(WorldToWaterId, worldToWater);
+                _material.SetVector(WaterSizeId, new Vector4(waterSize.x, waterSize.y, 1.0f / Mathf.Max(1e-4f, waterSize.x), 1.0f / Mathf.Max(1e-4f, waterSize.y)));
+                _material.SetVector(WaterGridParamsId, new Vector4(gridX, gridY, 1.0f / Mathf.Max(1, gridX), 1.0f / Mathf.Max(1, gridY)));
+                _material.SetFloat(WaterNormalTexelSizeId, normalTexelSize);
+                _material.SetVector(SunDirId, new Vector4(sunDir.x, sunDir.y, sunDir.z, 0.0f));
+                _material.SetColor(TintId, manager.Tint);
+                _material.SetFloat(IntensityId, manager.Intensity);
+                _material.SetFloat(FresnelF0Id, manager.F0);
+                _material.SetFloat(JacobianGainId, manager.JacobianGain);
+
+                foreach (CausticsReceiverPlane receiver in receivers)
+                {
+                    if (receiver == null)
+                    {
+                        continue;
+                    }
+
+                    RenderTexture target = receiver.CausticsRT;
+                    if (target == null)
+                    {
+                        continue;
+                    }
+
+                    if (!target.IsCreated())
+                    {
+                        target.Create();
+                    }
+
+                    cmd.SetRenderTarget(target);
+                    cmd.ClearRenderTarget(false, true, Color.black);
+                    cmd.SetViewport(new Rect(0, 0, target.width, target.height));
+
+                    _material.SetMatrix(PlaneToWorldId, receiver.PlaneToWorld);
+                    _material.SetMatrix(WorldToPlaneId, receiver.WorldToPlane);
+                    _material.SetVector(PlaneSizeId, new Vector4(receiver.sizeMeters.x, receiver.sizeMeters.y, 1.0f / Mathf.Max(1e-4f, receiver.sizeMeters.x), 1.0f / Mathf.Max(1e-4f, receiver.sizeMeters.y)));
+                    _material.SetVector(ReceiverResolutionId, new Vector4(target.width, target.height, 1.0f / Mathf.Max(1, target.width), 1.0f / Mathf.Max(1, target.height)));
+                    _material.SetFloat(PlaneDistanceToleranceId, receiver.planeDistanceTolerance);
+                    _material.SetFloat(PlaneTwoSidedId, receiver.twoSided ? 1.0f : 0.0f);
+
+                    cmd.DrawProcedural(Matrix4x4.identity, _material, 0, MeshTopology.Points, instanceCount, 1);
+                }
+            }
+
+            context.ExecuteCommandBuffer(cmd);
+            CommandBufferPool.Release(cmd);
+        }
+    }
+}

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsGenPass.cs.meta
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsGenPass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42073ce8db404a4e8a6139941a6ad684
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: { instanceID: 0 }
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsRendererFeature.cs
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsRendererFeature.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+namespace CausticsReflective
+{
+    public class ReflectiveCausticsRendererFeature : ScriptableRendererFeature
+    {
+        [System.Serializable]
+        public class Settings
+        {
+            [Tooltip("Shader used to generate reflective caustics.")]
+            public Shader genShader;
+
+            [Tooltip("Render pass event for the caustics generation pass.")]
+            public RenderPassEvent renderPassEvent = RenderPassEvent.BeforeRenderingTransparents;
+        }
+
+        public Settings settings = new();
+
+        private ReflectiveCausticsGenPass _genPass;
+        private Material _genMaterial;
+
+        public override void Create()
+        {
+            if (settings.genShader == null)
+            {
+                settings.genShader = Shader.Find("CausticsReflective/ReflectiveCausticsGen");
+            }
+
+            if (settings.genShader != null)
+            {
+                _genMaterial = CoreUtils.CreateEngineMaterial(settings.genShader);
+            }
+
+            _genPass = new ReflectiveCausticsGenPass
+            {
+                renderPassEvent = settings.renderPassEvent
+            };
+        }
+
+        public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
+        {
+            if (_genPass == null)
+            {
+                return;
+            }
+
+            if (_genMaterial == null && settings.genShader != null)
+            {
+                _genMaterial = CoreUtils.CreateEngineMaterial(settings.genShader);
+            }
+
+            if (_genMaterial == null)
+            {
+                return;
+            }
+
+            _genPass.Setup(_genMaterial);
+            renderer.EnqueuePass(_genPass);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_genMaterial != null)
+            {
+                CoreUtils.Destroy(_genMaterial);
+                _genMaterial = null;
+            }
+        }
+    }
+}

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsRendererFeature.cs.meta
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsRendererFeature.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 236f8f5e956f4fdd906d66a50f1ad855
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: { instanceID: 0 }
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders.meta
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 68478ecbede24513afc247db38831ae5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders/ReflectiveCausticsGen.shader
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders/ReflectiveCausticsGen.shader
@@ -1,0 +1,183 @@
+Shader "CausticsReflective/ReflectiveCausticsGen"
+{
+    Properties
+    {
+    }
+
+    SubShader
+    {
+        Tags { "RenderPipeline"="UniversalRenderPipeline" }
+        Pass
+        {
+            Name "Gen"
+            Blend One One
+            ZWrite Off
+            Cull Off
+            ZTest Always
+
+            HLSLPROGRAM
+            #pragma vertex Vert
+            #pragma fragment Frag
+            #pragma target 4.5
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            struct Attributes
+            {
+                uint vertexID : SV_VertexID;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+                float cosTheta : TEXCOORD0;
+                float weight : TEXCOORD1;
+            };
+
+            TEXTURE2D(_WaterNormalTex);
+            SAMPLER(sampler_WaterNormalTex);
+            TEXTURE2D(_WaterHeightTex);
+            SAMPLER(sampler_WaterHeightTex);
+
+            CBUFFER_START(UnityPerMaterial)
+            float4x4 _WaterToWorld;
+            float4x4 _WorldToWater;
+            float4x4 _PlaneToWorld;
+            float4x4 _WorldToPlane;
+            float4 _WaterSize;          // xy = size, zw = inv size
+            float4 _WaterGridParams;    // xy = grid counts, zw = inv counts
+            float4 _PlaneSize;          // xy = size, zw = inv size
+            float4 _ReceiverResolution; // xy = size, zw = inv size
+            float4 _SunDir;             // xyz = direction
+            float4 _Tint;
+            float _Intensity;
+            float _F0;
+            float _JacobianGain;
+            float _WaterNormalTexelSize;
+            float _PlaneDistanceTolerance;
+            float _PlaneTwoSided;
+            float _Padding0;
+            float _Padding1;
+            CBUFFER_END
+
+            float3 SampleWaterNormal(float2 uv)
+            {
+                float3 encoded = SAMPLE_TEXTURE2D(_WaterNormalTex, sampler_WaterNormalTex, uv).xyz;
+                float3 normalTS = normalize(encoded * 2.0 - 1.0);
+                return normalTS;
+            }
+
+            float FresnelPlaceholder(float cosTheta)
+            {
+                float F0 = saturate(_F0);
+                float oneMinus = 1.0 - saturate(cosTheta);
+                return F0 + (1.0 - F0) * pow(oneMinus, 5.0);
+            }
+
+            float JacobianPlaceholder(float baseWeight)
+            {
+                return max(0.0, _JacobianGain) * baseWeight;
+            }
+
+            Varyings Vert(Attributes input)
+            {
+                Varyings output;
+                output.positionCS = float4(-1.0, -1.0, 0.0, 1.0);
+                output.weight = 0.0;
+                output.cosTheta = 1.0;
+
+                uint gridCountX = (uint)max(1.0, round(_WaterGridParams.x));
+                uint gridCountY = (uint)max(1.0, round(_WaterGridParams.y));
+                float2 invGrid = float2(1.0 / gridCountX, 1.0 / gridCountY);
+
+                uint sampleIndex = input.vertexID;
+                uint sampleX = sampleIndex % gridCountX;
+                uint sampleY = sampleIndex / gridCountX;
+
+                if (sampleY >= gridCountY)
+                {
+                    return output;
+                }
+
+                float2 waterUV = (float2(sampleX, sampleY) + 0.5) * invGrid;
+
+                float2 waterLocalXZ = (waterUV - 0.5) * _WaterSize.xy;
+                float4 waterLocal = float4(waterLocalXZ.x, 0.0, waterLocalXZ.y, 1.0);
+                float3 waterWorld = mul(_WaterToWorld, waterLocal).xyz;
+
+                float3 normalLocal = float3(0.0, 1.0, 0.0);
+                if (_WaterNormalTexelSize > 0.0)
+                {
+                    float3 sampled = SampleWaterNormal(waterUV);
+                    normalLocal = normalize(float3(sampled.x, sampled.z, sampled.y));
+                }
+
+                float3x3 waterToWorld3x3 = (float3x3)_WaterToWorld;
+                float3 normalWS = normalize(mul(waterToWorld3x3, normalLocal));
+
+                float3 sunDir = _SunDir.xyz;
+                float sunLen = max(1e-4, length(sunDir));
+                float3 lightDir = -sunDir / sunLen;
+
+                float3 reflectDir = reflect(-lightDir, normalWS);
+
+                float3 originPlane = mul(_WorldToPlane, float4(waterWorld, 1.0)).xyz;
+                float3 dirPlane = mul((float3x3)_WorldToPlane, reflectDir);
+
+                float denom = dirPlane.y;
+                if (abs(denom) < max(1e-4, _PlaneDistanceTolerance))
+                {
+                    return output;
+                }
+
+                float t = -originPlane.y / denom;
+                if (t <= 0.0)
+                {
+                    return output;
+                }
+
+                if (_PlaneTwoSided < 0.5)
+                {
+                    if (originPlane.y <= 0.0 || denom >= 0.0)
+                    {
+                        return output;
+                    }
+                }
+
+                float3 hitPlane = originPlane + dirPlane * t;
+                float2 planeUV = hitPlane.xz * _PlaneSize.zw + 0.5;
+                float2 planeUVClamped = saturate(planeUV);
+
+                output.positionCS = float4(planeUVClamped * 2.0 - 1.0, 0.0, 1.0);
+
+                if (planeUV.x < 0.0 || planeUV.x > 1.0 || planeUV.y < 0.0 || planeUV.y > 1.0)
+                {
+                    return output;
+                }
+
+                float cosTheta = saturate(dot(normalWS, -lightDir));
+                output.cosTheta = cosTheta;
+
+                float cellArea = (_WaterSize.x * _WaterSize.y) * invGrid.x * invGrid.y;
+                output.weight = JacobianPlaceholder(cellArea);
+
+                return output;
+            }
+
+            half4 Frag(Varyings input) : SV_Target
+            {
+                float weight = input.weight;
+                if (weight <= 0.0)
+                {
+                    discard;
+                }
+
+                float fresnel = FresnelPlaceholder(input.cosTheta);
+                float energy = weight * fresnel * _Intensity;
+                float3 rgb = _Tint.rgb * energy;
+                return half4(rgb, energy);
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders/ReflectiveCausticsGen.shader.meta
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders/ReflectiveCausticsGen.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d595c16d07b54f78a244ec0ba4b94916
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- ReflectiveCausticsRendererFeature と ReflectiveCausticsGenPass を追加し、登録された受光プレーンへカスタム RT を生成する Gen パスを実行
- 水面情報・ライト方向・F0/Jacobian パラメータをマテリアルに送って、反射ベクトルとプレーン交差を求める HLSL シェーダー (Blend One One) を実装
- 各受光プレーンの CausticsRT をクリアし、ポイントベースのグリッドからアディティブに書き込むプロシージャル描画を構成

## Test Plan
- サンプルシーンを開き、ReflectiveCausticsRendererFeature を URP Renderer に追加
- Scene ビューの Frame Debugger で "ReflectiveCausticsGen" コマンドを選択し、各 CausticsRT が更新されていることを確認
- または CausticsRT を Debug 用マテリアルに割り当て、Game ビュー上で輝度分布を確認

## Screenshots
- 現在のクラウド環境では Unity エディタを起動できないため、CausticsRT のスクリーンショットは後日ローカル確認時に追加予定です。

closes #3

------
https://chatgpt.com/codex/tasks/task_b_68cd74a9f97c83288cb98309c26f6c56