### PR TITLE
[RC-005] Composite Pass

### DIFF
--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsCompositePass.cs
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsCompositePass.cs
@@ -32,6 +32,7 @@ namespace CausticsReflective
         private RenderTargetIdentifier _colorTarget;
         private RenderTargetIdentifier _depthTarget;
         private bool _multiplyBlend;
+        private bool _tempColorAllocated;
 
         public ReflectiveCausticsCompositePass(Material material)
         {
@@ -78,6 +79,7 @@ namespace CausticsReflective
                 descriptor.bindMS = false;
                 descriptor.enableRandomWrite = false;
                 cmd.GetTemporaryRT(TempColorId, descriptor, FilterMode.Bilinear);
+                _tempColorAllocated = true;
 
                 Blit(cmd, _colorTarget, TempColorId);
 
@@ -91,7 +93,11 @@ namespace CausticsReflective
 
         public override void OnCameraCleanup(CommandBuffer cmd)
         {
-            cmd.ReleaseTemporaryRT(TempColorId);
+            if (_tempColorAllocated)
+            {
+                cmd.ReleaseTemporaryRT(TempColorId);
+                _tempColorAllocated = false;
+            }
         }
 
         private static void PopulateShaderData(CommandBuffer cmd, ReflectiveCausticsManager manager, IReadOnlyList<CausticsReceiverPlane> receivers)

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsCompositePass.cs
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsCompositePass.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+namespace CausticsReflective
+{
+    public class ReflectiveCausticsCompositePass : ScriptableRenderPass
+    {
+        private const int MaxReceivers = 4;
+
+        private static readonly int ReceiverCountId = Shader.PropertyToID("_RC_ReceiverCount");
+        private static readonly int WorldToPlaneId = Shader.PropertyToID("_RC_WorldToPlane");
+        private static readonly int PlaneInfoId = Shader.PropertyToID("_RC_PlaneInfo");
+        private static readonly int TintIntensityId = Shader.PropertyToID("_RC_TintIntensity");
+        private static readonly int MultiplyBlendId = Shader.PropertyToID("_RC_MultiplyBlend");
+        private static readonly int TempColorId = Shader.PropertyToID("_RC_TempColorTexture");
+        private static readonly int[] CausticsTextureIds =
+        {
+            Shader.PropertyToID("_RC_CausticsTex0"),
+            Shader.PropertyToID("_RC_CausticsTex1"),
+            Shader.PropertyToID("_RC_CausticsTex2"),
+            Shader.PropertyToID("_RC_CausticsTex3"),
+        };
+
+        private static readonly Matrix4x4[] WorldToPlaneBuffer = new Matrix4x4[MaxReceivers];
+        private static readonly Vector4[] PlaneInfoBuffer = new Vector4[MaxReceivers];
+
+        private readonly ProfilingSampler _profilingSampler = new("Reflective Caustics Composite");
+        private readonly Material _material;
+
+        private RenderTargetIdentifier _colorTarget;
+        private RenderTargetIdentifier _depthTarget;
+        private bool _multiplyBlend;
+
+        public ReflectiveCausticsCompositePass(Material material)
+        {
+            _material = material;
+            renderPassEvent = RenderPassEvent.AfterRenderingOpaques;
+            ConfigureInput(ScriptableRenderPassInput.Depth);
+        }
+
+        public void Setup(RenderTargetIdentifier colorTarget, RenderTargetIdentifier depthTarget, bool multiplyBlend)
+        {
+            _colorTarget = colorTarget;
+            _depthTarget = depthTarget;
+            _multiplyBlend = multiplyBlend;
+        }
+
+        public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
+        {
+            ConfigureTarget(_colorTarget, _depthTarget);
+        }
+
+        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+        {
+            if (_material == null)
+            {
+                return;
+            }
+
+            var manager = ReflectiveCausticsManager.Instance;
+            var receivers = ReflectiveCausticsManager.Receivers;
+
+            if (manager == null || receivers == null || receivers.Count == 0)
+            {
+                return;
+            }
+
+            var cmd = CommandBufferPool.Get();
+            using (new ProfilingScope(cmd, _profilingSampler))
+            {
+                PopulateShaderData(cmd, manager, receivers);
+
+                var descriptor = renderingData.cameraData.cameraTargetDescriptor;
+                descriptor.depthBufferBits = 0;
+                descriptor.msaaSamples = 1;
+                descriptor.bindMS = false;
+                descriptor.enableRandomWrite = false;
+                cmd.GetTemporaryRT(TempColorId, descriptor, FilterMode.Bilinear);
+
+                Blit(cmd, _colorTarget, TempColorId);
+
+                cmd.SetGlobalFloat(MultiplyBlendId, _multiplyBlend ? 1f : 0f);
+                Blit(cmd, TempColorId, _colorTarget, _material);
+            }
+
+            context.ExecuteCommandBuffer(cmd);
+            CommandBufferPool.Release(cmd);
+        }
+
+        public override void OnCameraCleanup(CommandBuffer cmd)
+        {
+            cmd.ReleaseTemporaryRT(TempColorId);
+        }
+
+        private static void PopulateShaderData(CommandBuffer cmd, ReflectiveCausticsManager manager, IReadOnlyList<CausticsReceiverPlane> receivers)
+        {
+            var tintLinear = manager.Tint.linear;
+            cmd.SetGlobalVector(TintIntensityId, new Vector4(tintLinear.r, tintLinear.g, tintLinear.b, manager.Intensity));
+
+            var count = Mathf.Min(receivers.Count, MaxReceivers);
+            for (var i = 0; i < MaxReceivers; i++)
+            {
+                if (i < count)
+                {
+                    var receiver = receivers[i];
+                    WorldToPlaneBuffer[i] = receiver.WorldToPlane;
+                    PlaneInfoBuffer[i] = new Vector4(receiver.sizeMeters.x, receiver.sizeMeters.y, receiver.planeDistanceTolerance, receiver.twoSided ? 1f : 0f);
+                    var texture = receiver.CausticsRT != null ? receiver.CausticsRT : Texture2D.blackTexture;
+                    cmd.SetGlobalTexture(CausticsTextureIds[i], texture);
+                }
+                else
+                {
+                    WorldToPlaneBuffer[i] = Matrix4x4.identity;
+                    PlaneInfoBuffer[i] = Vector4.zero;
+                    cmd.SetGlobalTexture(CausticsTextureIds[i], Texture2D.blackTexture);
+                }
+            }
+
+            cmd.SetGlobalInt(ReceiverCountId, count);
+            cmd.SetGlobalMatrixArray(WorldToPlaneId, WorldToPlaneBuffer);
+            cmd.SetGlobalVectorArray(PlaneInfoId, PlaneInfoBuffer);
+        }
+    }
+}

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsCompositePass.cs.meta
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsCompositePass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92a08248da804921a9462d551a756293
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: { instanceID: 0 }
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders.meta
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 91219cab896a4977b11b374e76348bc1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders/ReflectiveCausticsComposite.shader
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders/ReflectiveCausticsComposite.shader
@@ -1,0 +1,188 @@
+Shader "Hidden/CausticsReflective/Composite"
+{
+    Properties
+    {
+    }
+
+    SubShader
+    {
+        Tags { "RenderType" = "Opaque" "RenderPipeline" = "UniversalPipeline" }
+        Cull Off ZWrite Off ZTest Always
+
+        Pass
+        {
+            Name "Composite"
+            Blend One Zero
+
+            HLSLPROGRAM
+            #pragma target 4.5
+            #pragma vertex Vert
+            #pragma fragment Frag
+            #pragma multi_compile_fragment _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+            #pragma multi_compile_fragment _ _SHADOWS_SOFT
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+
+            #define RC_MAX_RECEIVERS 4
+
+            TEXTURE2D(_MainTex);
+            SAMPLER(sampler_MainTex);
+
+            TEXTURE2D(_RC_CausticsTex0);
+            SAMPLER(sampler_RC_CausticsTex0);
+            TEXTURE2D(_RC_CausticsTex1);
+            SAMPLER(sampler_RC_CausticsTex1);
+            TEXTURE2D(_RC_CausticsTex2);
+            SAMPLER(sampler_RC_CausticsTex2);
+            TEXTURE2D(_RC_CausticsTex3);
+            SAMPLER(sampler_RC_CausticsTex3);
+
+            CBUFFER_START(RCCompositeParams)
+                float4 _RC_TintIntensity; // rgb tint, w intensity
+                float _RC_MultiplyBlend;
+                float3 _RC_Padding0;
+                float4 _RC_PlaneInfo[RC_MAX_RECEIVERS]; // xy size, z tolerance, w two sided flag
+                float4x4 _RC_WorldToPlane[RC_MAX_RECEIVERS];
+                int _RC_ReceiverCount;
+                float3 _RC_Padding1;
+            CBUFFER_END
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            Varyings Vert(Attributes input)
+            {
+                Varyings output;
+                output.positionCS = TransformVertex(input.positionOS);
+                output.uv = input.uv;
+                return output;
+            }
+
+            float SampleCausticsTexture(int index, float2 uv)
+            {
+                float sampleValue = 0.0;
+
+                if (index == 0)
+                {
+                    sampleValue = SAMPLE_TEXTURE2D(_RC_CausticsTex0, sampler_RC_CausticsTex0, uv).r;
+                }
+                else if (index == 1)
+                {
+                    sampleValue = SAMPLE_TEXTURE2D(_RC_CausticsTex1, sampler_RC_CausticsTex1, uv).r;
+                }
+                else if (index == 2)
+                {
+                    sampleValue = SAMPLE_TEXTURE2D(_RC_CausticsTex2, sampler_RC_CausticsTex2, uv).r;
+                }
+                else if (index == 3)
+                {
+                    sampleValue = SAMPLE_TEXTURE2D(_RC_CausticsTex3, sampler_RC_CausticsTex3, uv).r;
+                }
+
+                return sampleValue;
+            }
+
+            float3 ComputeWorldPosition(float2 uv, float deviceDepth)
+            {
+                return ComputeWorldSpacePosition(uv, deviceDepth, UNITY_MATRIX_I_VP);
+            }
+
+            half4 Frag(Varyings input) : SV_Target
+            {
+                const half4 baseColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv);
+
+                const float rawDepth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, sampler_CameraDepthTexture, input.uv);
+                if (rawDepth >= 1.0 - 1e-5)
+                {
+                    return baseColor;
+                }
+
+                const float3 worldPos = ComputeWorldPosition(input.uv, rawDepth);
+
+                float bestDistance = 1e20;
+                float causticsIntensity = 0.0;
+                bool foundReceiver = false;
+
+                [unroll]
+                for (int i = 0; i < RC_MAX_RECEIVERS; ++i)
+                {
+                    if (i >= _RC_ReceiverCount)
+                    {
+                        break;
+                    }
+
+                    const float4x4 worldToPlane = _RC_WorldToPlane[i];
+                    const float3 planePos = mul(worldToPlane, float4(worldPos, 1.0)).xyz;
+
+                    const float signedDistance = planePos.z;
+                    const float distance = abs(signedDistance);
+                    const float tolerance = _RC_PlaneInfo[i].z;
+                    if (distance > tolerance)
+                    {
+                        continue;
+                    }
+
+                    const bool twoSided = _RC_PlaneInfo[i].w > 0.5;
+                    if (!twoSided && signedDistance < 0.0)
+                    {
+                        continue;
+                    }
+
+                    const float halfWidth = _RC_PlaneInfo[i].x * 0.5;
+                    const float halfHeight = _RC_PlaneInfo[i].y * 0.5;
+                    if (abs(planePos.x) > halfWidth || abs(planePos.y) > halfHeight)
+                    {
+                        continue;
+                    }
+
+                    if (distance < bestDistance)
+                    {
+                        bestDistance = distance;
+                        float2 uvPlane = planePos.xy / float2(_RC_PlaneInfo[i].x, _RC_PlaneInfo[i].y) + 0.5;
+                        uvPlane = saturate(uvPlane);
+                        causticsIntensity = SampleCausticsTexture(i, uvPlane);
+                        foundReceiver = true;
+                    }
+                }
+
+                if (!foundReceiver)
+                {
+                    return baseColor;
+                }
+
+                float shadowAtten = 1.0;
+            #if defined(MAIN_LIGHT_SHADOWS) || defined(MAIN_LIGHT_SHADOWS_CASCADE)
+                const float4 shadowCoord = TransformWorldToShadowCoord(worldPos);
+                shadowAtten = MainLightRealtimeShadow(shadowCoord);
+            #endif
+
+                const float3 tint = _RC_TintIntensity.rgb * _RC_TintIntensity.w;
+                const float3 caustics = causticsIntensity.xxx * tint * shadowAtten;
+
+                float3 color = baseColor.rgb;
+                if (_RC_MultiplyBlend > 0.5)
+                {
+                    color *= (1.0 + caustics);
+                }
+                else
+                {
+                    color += caustics;
+                }
+
+                return half4(color, baseColor.a);
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders/ReflectiveCausticsComposite.shader.meta
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders/ReflectiveCausticsComposite.shader.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72154de342e94ed3975a70414e84faab
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorMacros: []
+  shaderVariantLogLevel: 0
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- ReflectiveCausticsCompositePass を追加し、Opaque 後にフルスクリーン合成を行う URP パスを実装
- 受信平面データとマネージャー設定をシェーダーへ転送し、距離判定・シャドウ減衰・乗算/加算ブレンドを反映するカスタムシェーダーを実装

## Test Plan
- （準備）Reflective Caustics 用の URP Renderer Feature に本パスを組み込み、CausticsReceiverPlane を含むデモシーンを開く
- Play モードでシーンを再生し、壁面（CausticsReceiverPlane）に映るカースティクスが Tint・Intensity・Multiply/Add 切り替え・シャドウ減衰に追従することを確認
- パスを無効化した場合に壁面からカースティクスが消えることを比較し、最も近い受信平面のみが寄与していることを確認

## Screenshots
- クラウド環境では Unity を起動できないため、ローカル検証時に Composite 無効/有効の比較スクリーンショットを取得し添付してください

closes #5

------
https://chatgpt.com/codex/tasks/task_b_68cd753e96948328b51acfe2f70152da