### PR TITLE
[RC-005] Composite Pass – RC-003 世代パスとの競合解消

### DIFF
--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsGenPass.cs
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsGenPass.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+namespace CausticsReflective
+{
+    public class ReflectiveCausticsGenPass : ScriptableRenderPass
+    {
+        private const int MaxReceivers = 4;
+
+        private static readonly int WaterNormalTexId = Shader.PropertyToID("_RC_WaterNormalTex");
+        private static readonly int WaterHeightTexId = Shader.PropertyToID("_RC_WaterHeightTex");
+        private static readonly int WaterToWorldId = Shader.PropertyToID("_RC_WaterToWorld");
+        private static readonly int WorldToWaterId = Shader.PropertyToID("_RC_WorldToWater");
+        private static readonly int WaterSizeMetersId = Shader.PropertyToID("_RC_WaterSizeMeters");
+        private static readonly int SunDirectionId = Shader.PropertyToID("_RC_SunDirection");
+        private static readonly int IntensityId = Shader.PropertyToID("_RC_Intensity");
+        private static readonly int FresnelF0Id = Shader.PropertyToID("_RC_F0");
+        private static readonly int JacobianGainId = Shader.PropertyToID("_RC_JacobianGain");
+        private static readonly int PlaneToWorldId = Shader.PropertyToID("_RC_PlaneToWorld");
+        private static readonly int WorldToPlaneId = Shader.PropertyToID("_RC_WorldToPlane");
+        private static readonly int PlaneOriginId = Shader.PropertyToID("_RC_PlaneOrigin");
+        private static readonly int PlaneNormalId = Shader.PropertyToID("_RC_PlaneNormal");
+        private static readonly int ReceiverParamsId = Shader.PropertyToID("_RC_ReceiverParams");
+        private static readonly int ReceiverResolutionId = Shader.PropertyToID("_RC_ReceiverResolution");
+
+        private readonly ProfilingSampler _profilingSampler = new("Reflective Caustics Generation");
+        private readonly Material _material;
+
+        private readonly Matrix4x4[] _planeToWorldCache = new Matrix4x4[MaxReceivers];
+
+        public ReflectiveCausticsGenPass(Material material)
+        {
+            _material = material;
+            renderPassEvent = RenderPassEvent.BeforeRenderingTransparents;
+        }
+
+        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+        {
+            if (_material == null)
+            {
+                return;
+            }
+
+            var manager = ReflectiveCausticsManager.Instance;
+            var receivers = ReflectiveCausticsManager.Receivers;
+
+            if (manager == null || manager.Water == null || receivers == null || receivers.Count == 0)
+            {
+                return;
+            }
+
+            var cmd = CommandBufferPool.Get();
+            using (new ProfilingScope(cmd, _profilingSampler))
+            {
+                PopulateSharedShaderData(cmd, manager);
+                RenderReceivers(cmd, receivers);
+            }
+
+            context.ExecuteCommandBuffer(cmd);
+            CommandBufferPool.Release(cmd);
+        }
+
+        private void PopulateSharedShaderData(CommandBuffer cmd, ReflectiveCausticsManager manager)
+        {
+            var water = manager.Water;
+
+            var normalTex = water.NormalTex != null ? water.NormalTex : Texture2D.normalTexture;
+            var heightTex = water.HeightTex != null ? water.HeightTex : Texture2D.blackTexture;
+            var waterToWorld = water.WaterToWorld;
+            var worldToWater = waterToWorld.inverse;
+
+            cmd.SetGlobalTexture(WaterNormalTexId, normalTex);
+            cmd.SetGlobalTexture(WaterHeightTexId, heightTex);
+            cmd.SetGlobalMatrix(WaterToWorldId, waterToWorld);
+            cmd.SetGlobalMatrix(WorldToWaterId, worldToWater);
+            cmd.SetGlobalVector(WaterSizeMetersId, new Vector4(water.WaterSizeMeters.x, water.WaterSizeMeters.y, Mathf.Max(1e-5f, water.NormalTexelSize), 0f));
+
+            var sunDirection = manager.Sun != null ? -manager.Sun.transform.forward : Vector3.down;
+            cmd.SetGlobalVector(SunDirectionId, new Vector4(sunDirection.x, sunDirection.y, sunDirection.z, 0f));
+            cmd.SetGlobalFloat(IntensityId, Mathf.Max(0f, manager.Intensity));
+            cmd.SetGlobalFloat(FresnelF0Id, Mathf.Clamp01(manager.F0));
+            cmd.SetGlobalFloat(JacobianGainId, Mathf.Max(0f, manager.JacobianGain));
+        }
+
+        private void RenderReceivers(CommandBuffer cmd, IReadOnlyList<CausticsReceiverPlane> receivers)
+        {
+            var count = Mathf.Min(receivers.Count, MaxReceivers);
+            for (var i = 0; i < count; i++)
+            {
+                var receiver = receivers[i];
+                if (receiver == null || receiver.CausticsRT == null)
+                {
+                    continue;
+                }
+
+                _planeToWorldCache[i] = receiver.PlaneToWorld;
+
+                ConfigureReceiver(cmd, receiver);
+
+                cmd.SetRenderTarget(receiver.CausticsRT);
+                cmd.ClearRenderTarget(false, true, Color.black);
+                cmd.DrawProcedural(Matrix4x4.identity, _material, 0, MeshTopology.Triangles, 3, 1);
+            }
+        }
+
+        private static void ConfigureReceiver(CommandBuffer cmd, CausticsReceiverPlane receiver)
+        {
+            var planeToWorld = receiver.PlaneToWorld;
+            var worldToPlane = receiver.WorldToPlane;
+            var planeOrigin = planeToWorld.MultiplyPoint(Vector3.zero);
+            var planeNormal = planeToWorld.MultiplyVector(Vector3.forward).normalized;
+
+            cmd.SetGlobalMatrix(PlaneToWorldId, planeToWorld);
+            cmd.SetGlobalMatrix(WorldToPlaneId, worldToPlane);
+            cmd.SetGlobalVector(PlaneOriginId, new Vector4(planeOrigin.x, planeOrigin.y, planeOrigin.z, 0f));
+            cmd.SetGlobalVector(PlaneNormalId, new Vector4(planeNormal.x, planeNormal.y, planeNormal.z, 0f));
+            cmd.SetGlobalVector(ReceiverParamsId, new Vector4(receiver.sizeMeters.x, receiver.sizeMeters.y, receiver.planeDistanceTolerance, receiver.twoSided ? 1f : 0f));
+            cmd.SetGlobalVector(ReceiverResolutionId, new Vector4(receiver.resolution.x, receiver.resolution.y, 1f / Mathf.Max(1, receiver.resolution.x), 1f / Mathf.Max(1, receiver.resolution.y)));
+        }
+    }
+}

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsGenPass.cs.meta
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Scripts/ReflectiveCausticsGenPass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 421096b6522e4128a82d10877c94759d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders/ReflectiveCausticsGen.shader
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders/ReflectiveCausticsGen.shader
@@ -1,0 +1,134 @@
+Shader "CausticsReflective/ReflectiveCausticsGen"
+{
+    Properties
+    {
+        [HideInInspector]_Unused("Unused", Float) = 0
+    }
+
+    SubShader
+    {
+        Tags { "RenderPipeline" = "UniversalPipeline" }
+        Pass
+        {
+            Name "ReflectiveCausticsGen"
+            ZWrite Off
+            ZTest Always
+            Cull Off
+            Blend One One
+
+            HLSLPROGRAM
+            #pragma vertex Vert
+            #pragma fragment Frag
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            struct Attributes
+            {
+                uint vertexID : SV_VertexID;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            CBUFFER_START(UnityPerMaterial)
+                float4x4 _RC_WaterToWorld;
+                float4x4 _RC_WorldToWater;
+                float4x4 _RC_PlaneToWorld;
+                float4x4 _RC_WorldToPlane;
+                float4 _RC_WaterSizeMeters; // xy: size meters, z: normal texel size
+                float4 _RC_SunDirection;    // xyz: direction (towards surface)
+                float4 _RC_ReceiverParams;  // xy: size meters, z: tolerance, w: two-sided flag
+                float4 _RC_ReceiverResolution;
+                float4 _RC_PlaneOrigin;     // xyz: plane origin
+                float4 _RC_PlaneNormal;     // xyz: plane normal
+                float _RC_Intensity;
+                float _RC_F0;
+                float _RC_JacobianGain;
+            CBUFFER_END
+
+            TEXTURE2D(_RC_WaterNormalTex);
+            SAMPLER(sampler_RC_WaterNormalTex);
+            TEXTURE2D(_RC_WaterHeightTex);
+            SAMPLER(sampler_RC_WaterHeightTex);
+
+            Varyings Vert(Attributes input)
+            {
+                Varyings output;
+                float2 uv = float2((input.vertexID << 1) & 2, input.vertexID & 2);
+                output.uv = uv;
+                output.positionCS = float4(uv * 2.0f - 1.0f, 0.0f, 1.0f);
+                return output;
+            }
+
+            float3 SampleWaterNormal(float2 uv)
+            {
+                float3 n = SAMPLE_TEXTURE2D(_RC_WaterNormalTex, sampler_RC_WaterNormalTex, uv).xyz * 2.0f - 1.0f;
+                float3x3 tbn = (float3x3)_RC_WaterToWorld;
+                return normalize(mul(tbn, n));
+            }
+
+            float SampleHeight(float2 uv)
+            {
+                return SAMPLE_TEXTURE2D(_RC_WaterHeightTex, sampler_RC_WaterHeightTex, uv).r;
+            }
+
+            float4 Frag(Varyings input) : SV_Target
+            {
+                float2 receiverSize = _RC_ReceiverParams.xy;
+                float2 planeLocal = (input.uv - 0.5f) * receiverSize;
+                float3 localPoint = float3(planeLocal, 0.0f);
+                float3 worldPoint = mul(_RC_PlaneToWorld, float4(localPoint, 1.0f)).xyz;
+
+                float3 planeNormal = normalize(_RC_PlaneNormal.xyz);
+                float3 sunDir = normalize(_RC_SunDirection.xyz);
+                float2 waterSize = max(_RC_WaterSizeMeters.xy, float2(1e-4f, 1e-4f));
+
+                float3 waterLocal = mul(_RC_WorldToWater, float4(worldPoint, 1.0f)).xyz;
+                float2 waterUv = waterLocal.xz / waterSize + 0.5f;
+                waterUv = saturate(waterUv);
+
+                float3 waterNormal = SampleWaterNormal(waterUv);
+                float3 reflected = normalize(reflect(-sunDir, waterNormal));
+
+                float denom = dot(reflected, planeNormal);
+                bool twoSided = _RC_ReceiverParams.w > 0.5f;
+
+                if ((!twoSided && denom >= -1e-4f) || (twoSided && abs(denom) <= 1e-4f))
+                {
+                    return 0;
+                }
+
+                float3 planeOrigin = _RC_PlaneOrigin.xyz;
+                float t = dot(planeOrigin - worldPoint, planeNormal) / denom;
+                if (t <= 0.0f)
+                {
+                    return 0;
+                }
+
+                float3 hitWorld = worldPoint + reflected * t;
+                float3 hitLocal = mul(_RC_WorldToPlane, float4(hitWorld, 1.0f)).xyz;
+                float2 halfSize = receiverSize * 0.5f;
+                if (abs(hitLocal.x) > halfSize.x + 1e-4f || abs(hitLocal.y) > halfSize.y + 1e-4f)
+                {
+                    return 0;
+                }
+
+                float distance = length(hitWorld - worldPoint);
+                float tolerance = max(1e-4f, _RC_ReceiverParams.z);
+                float distanceWeight = saturate(1.0f - distance / tolerance);
+
+                float cosTheta = saturate(dot(waterNormal, -sunDir));
+                float fresnel = _RC_F0 + (1.0f - _RC_F0) * pow(1.0f - cosTheta, 5.0f);
+                float focus = saturate(abs(denom));
+                float jacobian = pow(focus, 2.0f) * _RC_JacobianGain;
+
+                float intensity = fresnel * jacobian * distanceWeight * _RC_Intensity;
+                return float4(intensity, 0.0f, 0.0f, 1.0f);
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders/ReflectiveCausticsGen.shader.meta
+++ b/ReflectiveCausticsProject/Assets/CausticsReflective/Shaders/ReflectiveCausticsGen.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: a4043ec0ff274377ab994bbffc4ee9d1
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorDefines: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- ReflectiveCausticsGenPass.cs を追加し、マネージャー／受信平面情報をシェーダーへ転送する RC-003 世代パスのロジックを復元
- ReflectiveCausticsGen.shader を追加し、フルスクリーン描画で反射光の交点検出・距離減衰・フレネル係数を計算する RC-003 シェーダーを統合

## Test Plan
- ⚠️ Unity 実行環境がないためテスト未実施


------
https://chatgpt.com/codex/tasks/task_b_68d3b91ab2708328a09b934c28ba534c